### PR TITLE
Fix problematic backquote that causes zsh completion not working

### DIFF
--- a/contrib/completion/zsh/_termius
+++ b/contrib/completion/zsh/_termius
@@ -35,7 +35,7 @@ _termius() {
       "push[Send local changes to serveraudtor.com.]" \
       "snippet[Snippet operations.]" \
       "snippets[List snippets.]" \
-      "import-ssh-config[Import hosts from user`s ssh config.]" \
+      "import-ssh-config[Import hosts from user's ssh config.]" \
       "export-ssh-config[Export hosts from local storage to generated file.]" \
       "tags[List tags.]" \
       "settings[Configure application settings.]"


### PR DESCRIPTION
## Description of the change

My environment:
- MacOS 10.15.6
- zsh 5.7.1 (x86_64-apple-darwin19.0)

In my environment, zsh will complain about a unmatched " error when loading zsh completion file `_termius`.
The error goes like this: `/path/to/_termius:413: unmatched "`

After checking the source of `_termius`, I found it is the problematic backquote that causes the error and after correcting it to a single quote, the problem gets fixed.

I wonder if this is a rare case which only happens in macos + zsh environment like me since I didn't find any issues reporting it :/

## Type of change

- [ ] Feature
- [ ] Codebase Improvements
- [ ] Critical security bugs
- [x] Hotfix

## Reviewer's checklist

- [x] The code does not have any obvious logic errors.
- [ ] All cases specified in the requirements are fully implemented.
- [ ] There is sufficient automated testing for the new code. Existing automated tests were rewritten to account for code changes.
- [ ] The new code conforms to existing style guidelines.
